### PR TITLE
Implement scroll wheel zooming for using GLUT

### DIFF
--- a/mousemove.c
+++ b/mousemove.c
@@ -29,6 +29,12 @@
 
 #define EPSILON 0.0001
 
+/** Internal function to move camera along the look at vector
+ * @param amount Amount to translate camera down the lookVec
+ * @param lookVec Vector pointing where camera is looking
+ */
+void flyInOut(int amount, float* lookVec);
+
 /** Current camera lookat point (the lookat vector is created by subtracting the lookat point from the camera position. */
 static float cam_lookat[3];
 /** Current camera position */
@@ -153,9 +159,37 @@ void mousemove_buttonPress(int down, int leftMidRight, int x, int y)
 		// Store camera position & lookat when mouse button is pressed
 		vec3f_copy(cam_lookat_down, cam_lookat);
 		vec3f_copy(cam_position_down, cam_position);
+		if(leftMidRight>2)
+		{
+			float lookAt[3];
+			// Calculate a new vector pointing from the camera to the
+			// look at point and normalize it.
+			vec3f_sub_new(lookAt,cam_lookat_down,cam_position_down);
+			switch(cur_button)
+			{
+				case 3: // scrollUp (zoom in)
+					flyInOut(2,lookAt);
+				break;
+				case 4: // scrollDown (zoom out)
+					flyInOut(-2,lookAt);
+				break;
+				default: 
+				break;
+			}
+		}
 	}
 	else
 		cur_button = -1;
+}
+
+void flyInOut(int dy, float* lookVec){
+	// Move the camera and lookat point along the look vector
+	for(int i=0; i<3; i++)
+	{
+		float offset = lookVec[i] * -dy * settings_trans_scale;
+		cam_position[i] = cam_position_down[i] - offset;
+		cam_lookat[i]   = cam_lookat_down[i]   - offset;
+	}
 }
 
 /** This function should be called whenever a mouse cursor motion
@@ -219,14 +253,7 @@ int mousemove_movement(int x, int y)
 			break;
 
 		case 1: // middle mouse button - translate forward and back
-
-			// Move the camera and lookat point along the look vector
-			for(int i=0; i<3; i++)
-			{
-				float offset = f[i] * -dy * settings_trans_scale;
-				cam_position[i] = cam_position_down[i] - offset;
-				cam_lookat[i]   = cam_lookat_down[i]   - offset;
-			}
+			flyInOut(dy,f);
 			break;
 
 		case 2: // right mouse button - rotate
@@ -272,6 +299,9 @@ void mousemove_glutMouseFunc(int button, int state, int x, int y)
 		case GLUT_LEFT_BUTTON:   leftMidRight = 0;  break;
 		case GLUT_MIDDLE_BUTTON: leftMidRight = 1;  break;
 		case GLUT_RIGHT_BUTTON:  leftMidRight = 2;  break;
+		// FreeGLUT doesn't define these, which is weird, but they are scroll buttons.
+		case 3:                  leftMidRight = 3;  break; //up
+		case 4:                  leftMidRight = 4;  break; //down
 		default:                 leftMidRight = -1; break;
 	}
 	mousemove_buttonPress(state==GLUT_DOWN, leftMidRight, x, y);


### PR DESCRIPTION
So, on some thinkpads (with the little nub mouse), the middle mousebutton isn't always emulated when you press both left and right buttons (which is what happens on most other laptops).

Without a middle mouse button, the only other way to fly in and out is to use the scroll wheel events (which thinkpads _do_ produce).

This PR enables fly in/out on thinkpads, and scroll wheel fly in/out for normal mice.

Thanks,
Hurricane
