### PR TITLE
Update all examples to work on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,9 +46,11 @@ include_directories(${GLUT_INCLUDE_DIR})
 
 # Make sure freeglut installation is new enough!
 include(CheckSymbolExists)
-CHECK_SYMBOL_EXISTS(GLUT_CORE_PROFILE "${GLUT_INCLUDE_DIR}/GL/freeglut.h;${GLUT_INCLUDE_DIR}/GL/freeglut_ext.h" FREEGLUT_NEW_ENOUGH)
-if(NOT FREEGLUT_NEW_ENOUGH)
-  message(FATAL_ERROR "freeglut version 2.6 or higher is required.")
+if(NOT APPLE)
+  CHECK_SYMBOL_EXISTS(GLUT_CORE_PROFILE "${GLUT_INCLUDE_DIR}/GL/freeglut.h;${GLUT_INCLUDE_DIR}/GL/freeglut_ext.h" FREEGLUT_NEW_ENOUGH)
+  if(NOT FREEGLUT_NEW_ENOUGH)
+    message(FATAL_ERROR "freeglut version 2.6 or higher is required.")
+  endif()
 endif()
 
 # --- GLEW ---

--- a/CMakeModules/FindGLUT.cmake
+++ b/CMakeModules/FindGLUT.cmake
@@ -74,8 +74,6 @@
 # 
 #  * Kitware, Inc.
 
-include(FindPackageHandleStandardArgs)
-
 if (WIN32)
   find_path( GLUT_INCLUDE_DIR NAMES GL/glut.h
     PATHS  ${GLUT_ROOT_PATH}/include )
@@ -86,53 +84,57 @@ if (WIN32)
     )
 else ()
 
-  if (BEOS)
-
-    set(_GLUT_INC_DIR /boot/develop/headers/os/opengl)
-    set(_GLUT_glut_LIB_DIR /boot/develop/lib/x86)
-
-  else()
-
-    find_library( GLUT_Xi_LIBRARY Xi
-      /usr/openwin/lib
-      )
-
-    find_library( GLUT_Xmu_LIBRARY Xmu
-      /usr/openwin/lib
-      )
-
-  endif ()
-
-  find_path( GLUT_INCLUDE_DIR GL/glut.h
-	/usr/local/include
-    /usr/include/GL
-    /usr/openwin/share/include
-    /usr/openwin/include
-    /opt/graphics/OpenGL/include
-    /opt/graphics/OpenGL/contrib/libglut
-    ${_GLUT_INC_DIR}
-    )
-
-  find_library( GLUT_glut_LIBRARY glut
-	/usr/local/lib
-    /usr/openwin/lib
-    ${_GLUT_glut_LIB_DIR}
-    )
-
-  if (APPLE AND NOT GLUT_INCLUDE_DIR)
+  if (APPLE)
+    # These values for Apple could probably do with improvement.
     find_path( GLUT_INCLUDE_DIR glut.h
       /System/Library/Frameworks/GLUT.framework/Versions/A/Headers
       ${OPENGL_LIBRARY_DIR}
       )
     set(GLUT_glut_LIBRARY "-framework GLUT" CACHE STRING "GLUT library for OSX")
     set(GLUT_cocoa_LIBRARY "-framework Cocoa" CACHE STRING "Cocoa framework for OSX")
-  endif()
+  else ()
 
-  unset(_GLUT_INC_DIR)
-  unset(_GLUT_glut_LIB_DIR)
+    if (BEOS)
+
+      set(_GLUT_INC_DIR /boot/develop/headers/os/opengl)
+      set(_GLUT_glut_LIB_DIR /boot/develop/lib/x86)
+
+    else()
+
+      find_library( GLUT_Xi_LIBRARY Xi
+        /usr/openwin/lib
+        )
+
+      find_library( GLUT_Xmu_LIBRARY Xmu
+        /usr/openwin/lib
+        )
+
+    endif ()
+
+    find_path( GLUT_INCLUDE_DIR GL/glut.h
+      /usr/local/include
+      /usr/include/GL
+      /usr/openwin/share/include
+      /usr/openwin/include
+      /opt/graphics/OpenGL/include
+      /opt/graphics/OpenGL/contrib/libglut
+      ${_GLUT_INC_DIR}
+      )
+
+    find_library( GLUT_glut_LIBRARY glut
+      /usr/local/lib
+      /usr/openwin/lib
+      ${_GLUT_glut_LIB_DIR}
+      )
+
+    unset(_GLUT_INC_DIR)
+    unset(_GLUT_glut_LIB_DIR)
+
+  endif ()
 
 endif ()
 
+include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(GLUT REQUIRED_VARS GLUT_glut_LIBRARY GLUT_INCLUDE_DIR)
 
 if (GLUT_FOUND)

--- a/help/FREEGLUT-INSTALL.txt
+++ b/help/FREEGLUT-INSTALL.txt
@@ -7,6 +7,4 @@ libxmu-dev
 libxi-dev
 freeglut3-dev
 
-On OSX, XQuartz needs to be installed
-(http://xquartz.macosforge.org/landing/) before freeglut will install
-in homebrew.
+On OSX, the glut included with XCode should be sufficient.

--- a/kuhl-util.c
+++ b/kuhl-util.c
@@ -9,7 +9,11 @@
 
 
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 
 #define __GNU_SOURCE // make sure are allowed to use GNU extensions. Redundant if compiled with -std=gnu99
 

--- a/mousemove.c
+++ b/mousemove.c
@@ -8,7 +8,11 @@
  */
 
 #ifdef MOUSEMOVE_GLUT
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 #endif
 
 #ifdef MOUSEMOVE_GLFW

--- a/mousemove.h
+++ b/mousemove.h
@@ -59,7 +59,11 @@ extern "C" {
 #endif
 
 #ifdef MOUSEMOVE_GLUT
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 #endif
 
 #ifdef MOUSEMOVE_GLFW

--- a/ogl2-assimp.c
+++ b/ogl2-assimp.c
@@ -8,7 +8,11 @@
 #include <stdio.h>
 #include <math.h>
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 
 #include "kuhl-util.h"
 #include "dgr.h"
@@ -239,8 +243,8 @@ int main(int argc, char** argv)
 	/* Ask GLUT to for a double buffered, full color window that
 	 * includes a depth buffer */
 	glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH | GLUT_MULTISAMPLE);
-	glEnable(GL_MULTISAMPLE);
 	glutCreateWindow(argv[0]); // set window title to executable name
+	glEnable(GL_MULTISAMPLE);
 
 	/* Initialize GLEW */
 	GLenum glewError = glewInit();

--- a/ogl2-slideshow.c
+++ b/ogl2-slideshow.c
@@ -4,7 +4,11 @@
 #include <string.h>
 #include <unistd.h>
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 
 #include "kuhl-util.h"
 #include "imageio.h"

--- a/ogl2-texture.c
+++ b/ogl2-texture.c
@@ -2,7 +2,11 @@
 #include <stdio.h>
 #include <math.h>
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 
 #include "kuhl-util.h"
 #include "dgr.h"

--- a/ogl2-triangle.c
+++ b/ogl2-triangle.c
@@ -2,7 +2,11 @@
 #include <stdio.h>
 #include <math.h>
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 
 #include "kuhl-util.h"
 #include "dgr.h"

--- a/ogl3-assimp.c
+++ b/ogl3-assimp.c
@@ -368,8 +368,8 @@ int main(int argc, char** argv)
 	glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH | GLUT_MULTISAMPLE);
 	glutInitContextVersion(3,2);
 	glutInitContextProfile(GLUT_CORE_PROFILE);
-	glutCreateWindow(argv[0]); // set window title to executable name
 #endif
+	glutCreateWindow(argv[0]); // set window title to executable name
 	glEnable(GL_MULTISAMPLE);
 	
 	/* Initialize GLEW */

--- a/ogl3-picker.c
+++ b/ogl3-picker.c
@@ -7,7 +7,11 @@
 #include <stdio.h>
 #include <math.h>
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 
 #include "kuhl-util.h"
 #include "dgr.h"
@@ -267,9 +271,13 @@ int main(int argc, char** argv)
 	glutInitWindowSize(512, 512);
 	/* Ask GLUT to for a double buffered, full color window that
 	 * includes a depth buffer */
+#ifdef __APPLE__
+	glutInitDisplayMode(GLUT_3_2_CORE_PROFILE | GLUT_DOUBLE | GLUT_RGB | GLUT_STENCIL);
+#else
 	glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH | GLUT_STENCIL);
 	glutInitContextVersion(3,2);
 	glutInitContextProfile(GLUT_CORE_PROFILE);
+#endif
 	glutCreateWindow(argv[0]); // set window title to executable name
 
 	/* Initialize GLEW */

--- a/ogl3-prerend.c
+++ b/ogl3-prerend.c
@@ -2,7 +2,11 @@
 #include <stdio.h>
 #include <math.h>
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 
 #include "kuhl-util.h"
 #include "dgr.h"
@@ -243,9 +247,13 @@ int main(int argc, char** argv)
 	glutInitWindowSize(512, 512);
 	/* Ask GLUT to for a double buffered, full color window that
 	 * includes a depth buffer */
+#ifdef __APPLE__
+	glutInitDisplayMode(GLUT_3_2_CORE_PROFILE | GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
+#else
 	glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
 	glutInitContextVersion(3,2);
 	glutInitContextProfile(GLUT_CORE_PROFILE);
+#endif
 	glutCreateWindow(argv[0]); // set window title to executable name
 
 	/* Initialize GLEW */

--- a/ogl3-slerp.c
+++ b/ogl3-slerp.c
@@ -8,7 +8,11 @@
 #include <stdio.h>
 #include <math.h>
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 
 #include "kuhl-util.h"
 #include "dgr.h"
@@ -297,11 +301,15 @@ int main(int argc, char** argv)
 	glutInitWindowSize(512, 512);
 	/* Ask GLUT to for a double buffered, full color window that
 	 * includes a depth buffer */
+#ifdef __APPLE__
+	glutInitDisplayMode(GLUT_3_2_CORE_PROFILE | GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH | GLUT_MULTISAMPLE);
+#else
 	glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH | GLUT_MULTISAMPLE);
-	glEnable(GL_MULTISAMPLE);
 	glutInitContextVersion(3,2);
 	glutInitContextProfile(GLUT_CORE_PROFILE);
+#endif
 	glutCreateWindow(argv[0]); // set window title to executable name
+	glEnable(GL_MULTISAMPLE);
 
 	/* Initialize GLEW */
 	glewExperimental = GL_TRUE;

--- a/ogl3-texture.c
+++ b/ogl3-texture.c
@@ -2,7 +2,11 @@
 #include <stdio.h>
 #include <math.h>
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 
 #include "kuhl-util.h"
 #include "dgr.h"
@@ -172,9 +176,13 @@ int main(int argc, char** argv)
 	glutInitWindowSize(512, 512);
 	/* Ask GLUT to for a double buffered, full color window that
 	 * includes a depth buffer */
+#ifdef __APPLE__
+	glutInitDisplayMode(GLUT_3_2_CORE_PROFILE | GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
+#else
 	glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
 	glutInitContextVersion(3,2);
 	glutInitContextProfile(GLUT_CORE_PROFILE);
+#endif
 	glutCreateWindow(argv[0]); // set window title to executable name
 
 	/* Initialize GLEW */

--- a/ogl3-triangle-color.c
+++ b/ogl3-triangle-color.c
@@ -2,7 +2,11 @@
 #include <stdio.h>
 #include <math.h>
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 
 #include "kuhl-util.h"
 #include "dgr.h"
@@ -156,9 +160,13 @@ int main(int argc, char** argv)
 	glutInitWindowSize(512, 512);
 	/* Ask GLUT to for a double buffered, full color window that
 	 * includes a depth buffer */
+#ifdef __APPLE__
+	glutInitDisplayMode(GLUT_3_2_CORE_PROFILE | GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
+#else
 	glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
 	glutInitContextVersion(3,2);
 	glutInitContextProfile(GLUT_CORE_PROFILE);
+#endif
 	glutCreateWindow(argv[0]); // set window title to executable name
 
 	/* Initialize GLEW */

--- a/ogl3-triangle-shade.c
+++ b/ogl3-triangle-shade.c
@@ -2,7 +2,11 @@
 #include <stdio.h>
 #include <math.h>
 #include <GL/glew.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 
 #include "kuhl-util.h"
 #include "dgr.h"
@@ -209,9 +213,13 @@ int main(int argc, char** argv)
 	glutInitWindowSize(512, 512);
 	/* Ask GLUT to for a double buffered, full color window that
 	 * includes a depth buffer */
+#ifdef __APPLE__
+	glutInitDisplayMode(GLUT_3_2_CORE_PROFILE | GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
+#else
 	glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
 	glutInitContextVersion(3,2);
 	glutInitContextProfile(GLUT_CORE_PROFILE);
+#endif
 	glutCreateWindow(argv[0]); // set window title to executable name
 
 	/* Initialize GLEW */

--- a/ogl3-triangle.c
+++ b/ogl3-triangle.c
@@ -2,7 +2,12 @@
 #include <stdio.h>
 #include <math.h>
 #include <GL/glew.h>
+
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 
 #include "kuhl-util.h"
 #include "dgr.h"
@@ -178,9 +183,13 @@ int main(int argc, char** argv)
 	glutInitWindowSize(512, 512);
 	/* Ask GLUT to for a double buffered, full color window that
 	 * includes a depth buffer */
+#ifdef __APPLE__
+	glutInitDisplayMode(GLUT_3_2_CORE_PROFILE | GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
+#else
 	glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
 	glutInitContextVersion(3,2);
 	glutInitContextProfile(GLUT_CORE_PROFILE);
+#endif
 	glutCreateWindow(argv[0]); // set window title to executable name
 
 	/* Initialize GLEW */

--- a/projmat.c
+++ b/projmat.c
@@ -7,8 +7,13 @@
  * @author Scott Kuhl
  */
 
+#include <stdlib.h>
 #include <stdio.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 #include "kuhl-util.h"
 
 float projmat_frustum[6];

--- a/viewmat.c
+++ b/viewmat.c
@@ -7,8 +7,12 @@
  * @author Scott Kuhl
  */
 
-
+#include <stdlib.h>
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
 #include <GL/freeglut.h>
+#endif
 #include "kuhl-util.h"
 #include "mousemove.h"
 #include "vrpn-help.h"


### PR DESCRIPTION
This updates all examples to at least compile and run on OSX.

Note that I got the following error in ogl3-prerend though (it still ran):

```
!!!!! OpenGL Error !!!!! invalid enumerant - occurred before /Users/belak/opengl-examples/ogl3-prerend.c:57
```

Changes that may seem a little odd:
- FindGLUT.cmake - This was updated to a newer version of the file to fix an error relating to CMake trying to include Xi and Xmu on OSX. The paths /usr/local/include and /usr/local/lib were added to the respective locations (I think those were the only changes path wise? Please correct me if I'm wrong here.)
- CMakeLists.txt - We don't need freeglut on OSX. It's just the glut that comes with XCode. There are quite a few deprecation warnings though. This will probably have to change in a few years.

I tested all the examples at least once, simply to check if they ran. I can't make any promises (for sure) about them acting the same across platforms though as I haven't really seen them run on Ubuntu.
