### PR TITLE
Replace GL_CLAMP with GL_CLAMP_TO_EDGE in ogl3-prerend

### DIFF
--- a/ogl3-prerend.c
+++ b/ogl3-prerend.c
@@ -297,8 +297,8 @@ int main(int argc, char** argv)
 	glActiveTexture(GL_TEXTURE0);
 	glGenTextures(1, &prerenderTexID);
 	glBindTexture(GL_TEXTURE_2D, prerenderTexID);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 


### PR DESCRIPTION
This fixes the errors on OSX in ogl3-prerend. I believe GL_CLAMP was deprecated a while back and it looks like all the other code uses GL_CLAMP_TO_EDGE.
