### PR TITLE
Add HMD dsight orientation sensor support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,8 @@ if(BUILD_DOCUMENTATION)
 	if(DOXYGEN_FOUND)
 	#-- Add a custom target to run Doxygen when ever the project is built
 	add_custom_target (docs 
-                     COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/Doxyfile
-                     SOURCES ${PROJECT_BINARY_DIR}/Doxyfile)
+		COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_SOURCE_DIR}/Doxyfile
+		SOURCES ${CMAKE_SOURCE_DIR}/Doxyfile)
 	# Add or remove 'ALL' after 'docs' above to enable/disable doxygen generation when running "make"
 	endif()
 endif()
@@ -81,10 +81,10 @@ include_directories(${GLUT_INCLUDE_DIR})
 # Make sure freeglut installation is new enough!
 include(CheckSymbolExists)
 if(UNIX AND NOT APPLE)
-  CHECK_SYMBOL_EXISTS(GLUT_CORE_PROFILE "${GLUT_INCLUDE_DIR}/GL/freeglut.h;${GLUT_INCLUDE_DIR}/GL/freeglut_ext.h" FREEGLUT_NEW_ENOUGH)
-  if(NOT FREEGLUT_NEW_ENOUGH)
-    message(FATAL_ERROR "freeglut version 2.6 or higher is required.")
-  endif()
+	CHECK_SYMBOL_EXISTS(GLUT_CORE_PROFILE "${GLUT_INCLUDE_DIR}/GL/freeglut.h;${GLUT_INCLUDE_DIR}/GL/freeglut_ext.h" FREEGLUT_NEW_ENOUGH)
+	if(NOT FREEGLUT_NEW_ENOUGH)
+		message(FATAL_ERROR "freeglut version 2.6 or higher is required.")
+	endif()
 endif()
 
 # --- GLEW ---
@@ -109,7 +109,7 @@ include_directories(${GLEW_INCLUDE_DIRS})
 include(CheckSymbolExists)
 CHECK_SYMBOL_EXISTS(GL_ARB_get_program_binary "${GLEW_INCLUDE_DIRS}/GL/glew.h" GLEW_NEW_ENOUGH)
 if(NOT GLEW_NEW_ENOUGH)
-  message(FATAL_ERROR "glew version 1.5.6 or higher is required.")
+	message(FATAL_ERROR "glew version 1.5.6 or higher is required.")
 endif()
 
 # --- ImageMagick (recommended, optional) ---
@@ -193,7 +193,7 @@ endif()
 # make compilation rule for all programs that need ASSIMP and ImageMagick
 if(ASSIMP_FOUND AND ImageMagick_FOUND)
 	foreach(arg ${NEED_ASSIMP_AND_IM})
-		add_executable(${arg} ${arg}.c  kuhl-util.c vecmat.c dgr.c mousemove.c projmat.c viewmat.c vrpn-help.cpp imageio.c)
+		add_executable(${arg} ${arg}.c  kuhl-util.c vecmat.c dgr.c mousemove.c hmdcontrol.c projmat.c viewmat.c vrpn-help.cpp imageio.c)
 		target_link_libraries(${arg} ${COMMON_LIBRARIES} ${GLUT_LIBRARIES} ${ASSIMP_LIBRARIES} ${ImageMagick_LIBRARIES})
 		set_target_properties(${arg} PROPERTIES COMPILE_DEFINITIONS "KUHL_UTIL_USE_ASSIMP;KUHL_UTIL_USE_IMAGEMAGICK;MOUSEMOVE_GLUT;${MISSING_VRPN_DEFINITION}")
 	endforeach()
@@ -209,7 +209,7 @@ endif()
 # Make compilation rule for all programs that only need ImageMagick
 if(ImageMagick_FOUND)
 	foreach(arg ${NEED_IM})
-		add_executable(${arg} ${arg}.c kuhl-util.c vecmat.c dgr.c mousemove.c projmat.c viewmat.c vrpn-help.cpp imageio.c)
+		add_executable(${arg} ${arg}.c kuhl-util.c vecmat.c dgr.c mousemove.c hmdcontrol.c projmat.c viewmat.c vrpn-help.cpp imageio.c)
 		target_link_libraries(${arg} ${COMMON_LIBRARIES} ${GLUT_LIBRARIES} ${ImageMagick_LIBRARIES})
 		set_target_properties(${arg} PROPERTIES COMPILE_DEFINITIONS "KUHL_UTIL_USE_IMAGEMAGICK;MOUSEMOVE_GLUT;${MISSING_VRPN_DEFINITION}")
 	endforeach()
@@ -219,7 +219,7 @@ endif()
 
 # Make compilation rule for all programs that don't need ImageMagick or ASSIMIP
 foreach(arg ${NEED_NOTHING})
-	add_executable(${arg} ${arg}.c kuhl-util.c vecmat.c dgr.c mousemove.c projmat.c viewmat.c vrpn-help.cpp)
+	add_executable(${arg} ${arg}.c kuhl-util.c vecmat.c dgr.c mousemove.c hmdcontrol.c projmat.c viewmat.c vrpn-help.cpp)
 	target_link_libraries(${arg} ${COMMON_LIBRARIES} ${GLUT_LIBRARIES})
 	set_target_properties(${arg} PROPERTIES COMPILE_DEFINITIONS "MOUSEMOVE_GLUT;${MISSING_VRPN_DEFINITION}")
 endforeach()

--- a/hmd.sh
+++ b/hmd.sh
@@ -39,5 +39,6 @@ fi
 PATH=.:$PATH
 
 export VIEWMAT_MODE="hmd"
+export VIEWMAT_HMD_FILE="/dev/ttyACM0"
 "${@}"
 

--- a/hmdcontrol.c
+++ b/hmdcontrol.c
@@ -1,0 +1,100 @@
+/* Copyright (c) 2015 Scott Kuhl. All rights reserved.
+ * License: This code is licensed under a 3-clause BSD license. See
+ * the file named "LICENSE" for a full copy of the license.
+ */
+
+/** @file
+* @author Evan Hauck
+*/
+
+#include "hmdcontrol.h"
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
+// write "safe", a method that always succeeds (failure is handled by exit())
+void writeSafe(const int fd, const unsigned char* buf, size_t numBytes)
+{
+	while (numBytes > 0)
+	{
+		ssize_t result = write(fd, buf, numBytes);
+		if (result == -1)
+		{
+			if (errno == EAGAIN)
+			{
+				continue;
+			}
+			fprintf(stderr, "writeSafe failed, errno = %d\n", errno);
+			exit(EXIT_FAILURE);
+		}
+		buf += result;
+		numBytes -= (size_t)result;
+	}
+}
+
+// read "safe", same as writeSafe but for reading
+void readSafe(int fd, unsigned char* buf, size_t numBytes)
+{
+	while (numBytes > 0)
+	{
+		ssize_t result = read(fd, buf, numBytes);
+		if (result == -1)
+		{
+			if (errno == EAGAIN)
+			{
+				continue;
+			}
+			fprintf(stderr, "readSafe failed, errno = %d\n", errno);
+			exit(1);
+		}
+		buf += result;
+		numBytes -= (size_t)result;
+	}
+}
+
+void swapEndianessFloat(float* data, const int n)
+{
+	unsigned char* charData = (unsigned char*)data;
+	int i;
+	for (i = 0; i < n; i++)
+	{
+		unsigned char tmp;
+		tmp = charData[i * 4 + 0];
+		charData[i * 4 + 0] = charData[i * 4 + 3];
+		charData[i * 4 + 3] = tmp;
+		tmp = charData[i * 4 + 1];
+		charData[i * 4 + 1] = charData[i * 4 + 2];
+		charData[i * 4 + 2] = tmp;
+	}
+}
+
+HmdControlState initHmdControl(const char* deviceFile)
+{
+	HmdControlState result;
+	result.fd = open(deviceFile, O_RDWR | O_NOCTTY);
+	if (result.fd == -1)
+	{
+		fprintf(stderr, "Could not open %s for HMD rotation sensor driver\n", deviceFile);
+		exit(EXIT_FAILURE);
+	}
+	return result;
+}
+
+// http://stackoverflow.com/questions/2100331
+#define IS_BIG_ENDIAN (!*(unsigned char *)&(unsigned short){1})
+
+void updateHmdControl(HmdControlState *state, float quaternion[4])
+{
+	const unsigned char writeData[3] = { 0xf7, 0x00, 0x00 };
+	writeSafe(state->fd, writeData, 3);
+
+	readSafe(state->fd, (unsigned char*)quaternion, 4 * sizeof(float));
+	if (!IS_BIG_ENDIAN)
+	{
+		// HMD returns float in big-endian order
+		swapEndianessFloat(quaternion, 4);
+	}
+	// TODO: Not sure if quaternion itself is in right order, either.
+}

--- a/hmdcontrol.h
+++ b/hmdcontrol.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2015 Scott Kuhl. All rights reserved.
+ * License: This code is licensed under a 3-clause BSD license. See
+ * the file named "LICENSE" for a full copy of the license.
+ */
+
+/** @file
+* @author Evan Hauck
+*/
+
+#ifndef __HMDCONTROL_H__
+#define __HMDCONTROL_H__
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+	int fd;
+} HmdControlState;
+
+HmdControlState initHmdControl(const char* deviceFile);
+void updateHmdControl(HmdControlState *state, float quaternion[4]);
+
+#ifdef __cplusplus
+} // end extern "C"
+#endif
+#endif // __HMDCONTROL_H__


### PR DESCRIPTION
I haven't tested this yet, although I did test the methods in hmdcontrol.c in another project, just copied them over, so it should work (but it probably doesn't). Too cold to walk over to the lab to test now.

One issue with this is that there is no source of information for the absolute position of the HMD, so it's set to be a constant zero. This could be a problem, and we may need to refactor to take the position of the HMD via the VRPN tracking system. However, if we do that we may just want to use all of the VRPN's information including rotation, and ditch the internal sensor. It may turn out that the VRPN is too inaccurate for look/up vectors, though, in which case a dual system might be best.

Additionally, we might want to update hmd.sh to take the /dev file as a parameter instead of hardcoding /dev/ttyACM0. My bash skills aren't very good, so I didn't attempt to change that.

(khyperia = Evan Hauck, in case you're confused who I am)